### PR TITLE
Remove ralph from requirements. Now Ralph requires ralph_assets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
     package_dir={'': 'src'},
     zip_safe=False,  # because templates are loaded from file path
     install_requires=[
-        'ralph>=2.0.0-rc8',
         'django-mptt==0.5.5',
         'xlrd==0.9.2',
         'inkpy==0.1.0-alpha',


### PR DESCRIPTION
Movement device locations into ralph_assets and others caused a situation in which Ralph required ralph_assets.