### PR TITLE
Fixed create method in DeprecatedRalphDC and DeprecatedRalphRack

### DIFF
--- a/src/ralph_assets/models_dc_assets.py
+++ b/src/ralph_assets/models_dc_assets.py
@@ -79,6 +79,28 @@ class RackOrientation(Choices):
     right = _("right")
 
 
+class RequiredModelWithTypeMixin(object):
+    """
+    Mixin forces a model type in deprecated object (rack, dc).
+    """
+    _model_type = None
+
+    def __init__(self, *args, **kwargs):
+        if not self._model_type:
+            raise ValueError('Please provide _model_type')
+        super(RequiredModelWithTypeMixin, self).__init__(*args, **kwargs)
+
+    @classmethod
+    def create(cls, **kwargs):
+        if 'model' not in kwargs.iterkeys():
+            raise ValueError('Please provide model.')
+        elif kwargs['model'].type != cls._model_type:
+            raise ValueError(
+                'Model must be a {} type.'.format(cls._model_type.desc)
+            )
+        return cls(**kwargs)
+
+
 class DeprecatedRalphDCManager(models.Manager):
     def get_query_set(self):
         query_set = super(DeprecatedRalphDCManager, self).get_query_set()
@@ -86,7 +108,8 @@ class DeprecatedRalphDCManager(models.Manager):
         return data_centers
 
 
-class DeprecatedRalphDC(Device):
+class DeprecatedRalphDC(RequiredModelWithTypeMixin, Device):
+    _model_type = DeviceType.data_center
     objects = DeprecatedRalphDCManager()
 
     class Meta:
@@ -100,7 +123,8 @@ class DeprecatedRalphRackManager(models.Manager):
         return racks
 
 
-class DeprecatedRalphRack(Device):
+class DeprecatedRalphRack(RequiredModelWithTypeMixin, Device):
+    _model_type = DeviceType.rack
     objects = DeprecatedRalphRackManager()
 
     class Meta:

--- a/src/ralph_assets/tests/unit/tests_models.py
+++ b/src/ralph_assets/tests/unit/tests_models.py
@@ -13,8 +13,13 @@ from django.test import TestCase
 from ralph.business.models import Venture
 from ralph.discovery.models_device import Device, DeviceType
 
+from ralph.discovery.tests.util import DeviceModelFactory
 from ralph_assets.api_pricing import get_assets, get_asset_parts
 from ralph_assets.models_assets import AssetStatus, PartInfo, Rack
+from ralph_assets.models_dc_assets import (
+    DeprecatedRalphDC,
+    DeprecatedRalphRack,
+)
 from ralph_assets.licences.models import LicenceAsset, Licence, WrongModelError
 from ralph_assets.tests.utils.assets import (
     AssetSubCategoryFactory,
@@ -334,3 +339,35 @@ class TestModelRack(TestCase):
         ]
         children = chasiss.get_related_assets()
         self.assertEqual(children.count(), 5)
+
+
+class TestModelDeprecatedDataCenter(TestCase):
+
+    def test_create(self):
+        model = DeviceModelFactory(type=DeviceType.data_center)
+        self.assertTrue(DeprecatedRalphDC.create(name='DC', model=model))
+
+    def test_create_without_model(self):
+        with self.assertRaises(ValueError):
+            DeprecatedRalphDC.create(name='DC')
+
+    def test_create_with_incorrect_model(self):
+        model = DeviceModelFactory()
+        with self.assertRaises(ValueError):
+            DeprecatedRalphDC.create(name='DC', model=model)
+
+
+class TestModelDeprecatedRack(TestCase):
+
+    def test_create(self):
+        model = DeviceModelFactory(type=DeviceType.rack)
+        self.assertTrue(DeprecatedRalphRack.create(name='Rack', model=model))
+
+    def test_create_without_model(self):
+        with self.assertRaises(ValueError):
+            DeprecatedRalphRack.create(name='Rack')
+
+    def test_create_with_incorrect_model(self):
+        model = DeviceModelFactory()
+        with self.assertRaises(ValueError):
+            DeprecatedRalphRack.create(name='Rack', model=model)


### PR DESCRIPTION
Now ``DeprecatedRalphDC`` and ``DeprecatedRalphRack`` requires model with concrete type.