### PR TITLE
Skip liquidated assets in Scrooge API

### DIFF
--- a/src/ralph_assets/api_scrooge.py
+++ b/src/ralph_assets/api_scrooge.py
@@ -71,6 +71,9 @@ def get_assets(date):
         if not asset.device_environment_id:
             logger.error('Asset {0} has no environment'.format(asset.id))
             continue
+        if asset.is_liquidated(date):
+            logger.info("Skipping asset {} - it's liquidated")
+            continue
         device_info = asset.device_info
         hostname = None
         if device_info:

--- a/src/ralph_assets/models_assets.py
+++ b/src/ralph_assets/models_assets.py
@@ -833,6 +833,21 @@ class Asset(
             )
         return deprecation_date < date
 
+    def is_liquidated(self, date=None):
+        date = date or datetime.date.today()
+        # check if asset has status 'liquidated' and if yes, check if it has
+        # this status on given date
+        if self.status == AssetStatus.liquidated and self._liquidated_at(date):
+            return True
+        return False
+
+    def _liquidated_at(self, date):
+        liquidated_history = self.get_history().filter(
+            new_value='liquidated',
+            field_name='status',
+        ).order_by('-date')[:1]
+        return liquidated_history and liquidated_history[0].date.date() <= date
+
     def delete_with_info(self, *args, **kwargs):
         """
         Remove Asset with linked info-tables alltogether, because cascade

--- a/src/ralph_assets/tests/unit/test_api_scrooge.py
+++ b/src/ralph_assets/tests/unit/test_api_scrooge.py
@@ -5,6 +5,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import mock
 from datetime import date
 
 from django.test import TestCase
@@ -160,6 +161,16 @@ class TestApiScrooge(TestCase):
         today = date(2013, 11, 12)
         result = [a for a in api_scrooge.get_assets(today)]
         self.assertEquals(result, [])
+
+    @mock.patch('ralph_assets.models_assets.Asset.is_liquidated')
+    @mock.patch('ralph_assets.api_scrooge.logger')
+    def test_get_asset_liquidated(self, logger_mock, is_liquidated_mock):
+        is_liquidated_mock.return_value = True
+        DCAssetFactory()
+        today = date(2013, 11, 12)
+        result = [a for a in api_scrooge.get_assets(today)]
+        self.assertEquals(result, [])
+        self.assertTrue(logger_mock.info.called)
 
     def test_get_supports(self):
         DCSupportFactory(


### PR DESCRIPTION
Added Asset model method to check if asset has liquidated status on given date. If yes then skip this asset in Scrooge get_assets API - liquidated assets shouldn't be considered in billing.