### PR TITLE
Cascade reload on location fields

### DIFF
--- a/src/ralph_assets/forms.py
+++ b/src/ralph_assets/forms.py
@@ -12,6 +12,7 @@ from ajax_select.fields import (
     AutoCompleteSelectField,
     AutoCompleteField,
     AutoCompleteSelectMultipleField,
+    CascadeModelChoiceField,
 )
 from bob.forms import (
     AJAX_UPDATE,
@@ -35,7 +36,7 @@ from django.forms import (
     ModelForm,
     ValidationError,
 )
-from django.forms.widgets import HiddenInput, Textarea, TextInput
+from django.forms.widgets import HiddenInput, Select, Textarea, TextInput
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
@@ -54,6 +55,7 @@ from ralph_assets.models import (
     RALPH_DATE_FORMAT,
     Service,
 )
+from ralph_assets.models_dc_assets import DataCenter, ServerRoom, Rack
 from ralph_assets import models_assets
 from ralph.discovery import models_device
 from ralph.middleware import get_actual_regions
@@ -547,6 +549,30 @@ class DeviceForm(ModelForm):
     create_stock = BooleanField(
         required=False,
         label=_('Create stock device'),
+    )
+
+    data_center = ModelChoiceField(
+        label=_('data center'),
+        queryset=DataCenter.objects.all(),
+        required=True,
+        widget=Select(attrs={'id': 'data-center-selection'}),
+    )
+    server_room = CascadeModelChoiceField(
+        ('ralph_assets.models', 'ServerRoomLookup'),
+        label=_('Server room'),
+        queryset=ServerRoom.objects.all(),
+        required=True,
+
+        attrs={'id': 'server-room-selection'},
+        parent_field=data_center,
+    )
+    rack = CascadeModelChoiceField(
+        ('ralph_assets.models', 'RackLookup'),
+        label=_('Rack'),
+        queryset=Rack.objects.all(),
+        required=False,
+
+        parent_field=server_room,
     )
 
     def __init__(self, *args, **kwargs):

--- a/src/ralph_assets/models.py
+++ b/src/ralph_assets/models.py
@@ -49,10 +49,29 @@ from ralph.ui.channels import RestrictedLookupChannel
 from ralph_assets.models_util import (
     WithForm,
 )
+from ralph_assets.models_dc_assets import ServerRoom, Rack
 from ralph.discovery.models import Device, DeviceType
 
 
 RALPH_DATE_FORMAT = '%Y-%m-%d'
+
+
+class ServerRoomLookup(RestrictedLookupChannel):
+    model = ServerRoom
+
+    def get_query(self, pk, request):
+        return ServerRoom.objects.filter(
+            Q(data_center__pk=pk),
+        ).order_by('name')[:10]
+
+
+class RackLookup(RestrictedLookupChannel):
+    model = Rack
+
+    def get_query(self, pk, request):
+        return Rack.objects.filter(
+            Q(server_room__pk=pk)
+        ).order_by('name')[:10]
 
 
 class DeviceLookup(RestrictedLookupChannel):

--- a/src/ralph_assets/models_assets.py
+++ b/src/ralph_assets/models_assets.py
@@ -64,7 +64,7 @@ from ralph_assets.models_dc_assets import (  # noqa
     DeprecatedRalphRack,
     DeprecatedRalphRackManager,
     DeviceInfo,
-    INVALID_DATA_CENTER,
+    INVALID_RACK,
     INVALID_ORIENTATION,
     INVALID_POSITION,
     INVALID_SERVER_ROOM,

--- a/src/ralph_assets/models_dc_assets.py
+++ b/src/ralph_assets/models_dc_assets.py
@@ -32,7 +32,7 @@ from ralph.discovery.models_util import SavingUser
 
 logger = logging.getLogger(__name__)
 
-INVALID_DATA_CENTER = 1
+INVALID_RACK = 1
 INVALID_SERVER_ROOM = 2
 INVALID_ORIENTATION = 3
 INVALID_POSITION = 4
@@ -307,19 +307,13 @@ class DeviceInfo(TimeTrackable, SavingUser, SoftDeletable):
         """
         if self.rack and self.server_room:
             if self.rack.server_room != self.server_room:
-                msg = 'Valid server room for this rack is: "{}"'.format(
-                    self.rack.server_room.name,
-                )
-                raise ValidationError(
-                    {'server_room': msg}, code=INVALID_SERVER_ROOM,
-                )
+                msg = 'This rack is not from picked server room'
+                raise ValidationError({'rack': msg}, code=INVALID_RACK)
         if self.server_room and self.data_center:
             if self.server_room.data_center != self.data_center:
-                msg = 'Valid data center for this server room is: "{}"'.format(
-                    self.server_room.data_center.name,
-                )
+                msg = 'This server room is not from picked data center'
                 raise ValidationError(
-                    {'data_center': msg}, code=INVALID_DATA_CENTER,
+                    {'server_room': msg}, code=INVALID_SERVER_ROOM,
                 )
         if self.position == 0 and not Orientation.is_width(self.orientation):
             msg = 'Valid orientations for picked position are: {}'.format(

--- a/src/ralph_assets/tests/unit/tests_other.py
+++ b/src/ralph_assets/tests/unit/tests_other.py
@@ -401,7 +401,7 @@ class TestDeviceInfoValidation(TestCase):
         )
         with self.assertRaises(ValidationError) as exc:
             device_info.clean_fields()
-        self.assertEqual(exc.exception.code, models_assets.INVALID_DATA_CENTER)
+        self.assertEqual(exc.exception.code, models_assets.INVALID_SERVER_ROOM)
 
     def test_server_room_relation(self):
         '''test if picked rack is owned by picked server-room'''
@@ -419,7 +419,7 @@ class TestDeviceInfoValidation(TestCase):
         )
         with self.assertRaises(ValidationError) as exc:
             device_info.clean_fields()
-        self.assertEqual(exc.exception.code, models_assets.INVALID_SERVER_ROOM)
+        self.assertEqual(exc.exception.code, models_assets.INVALID_RACK)
 
     def test_position_requires_width(self):
         '''test if picked orientation is owned by picked position - width'''


### PR DESCRIPTION
Improved data center form by ajax reloads.

Added lookups and used them in data center form, so that when user picks data center, server rooms are populated only with server rooms belonging to picked data center.
Change is a UX improvement.

DEPENDS ON:
https://github.com/quamilek/bob-ajax-selects/pull/19

