### PR TITLE
Removed office info field from bulk edit

### DIFF
--- a/src/ralph_assets/forms.py
+++ b/src/ralph_assets/forms.py
@@ -478,8 +478,8 @@ class BackOfficeBulkEditAssetForm(BulkEditAssetForm):
             'type', 'status', 'barcode', 'hostname', 'model', 'user', 'owner',
             'warehouse', 'sn', 'property_of', 'purpose', 'remarks',
             'service_name', 'invoice_no', 'invoice_date', 'price', 'provider',
-            'task_url', 'office_info', 'deprecation_rate', 'order_no',
-            'source', 'deprecation_end_date',
+            'task_url', 'deprecation_rate', 'order_no', 'source',
+            'deprecation_end_date',
         )
 
     def __init__(self, *args, **kwargs):

--- a/src/ralph_assets/tests/functional/tests_bulkedit.py
+++ b/src/ralph_assets/tests/functional/tests_bulkedit.py
@@ -19,7 +19,6 @@ from ralph_assets.tests.utils.assets import (
     AssetCategoryFactory,
     AssetModelFactory,
     AssetOwnerFactory,
-    OfficeInfoFactory,
     ServiceFactory,
     WarehouseFactory,
 )
@@ -188,7 +187,6 @@ class TestBulkEdit(TestCase):
         bo_asset_data.update({
             'sn': 'bo-sn-number',
             'type': models_assets.AssetType.back_office,
-            'office_info': OfficeInfoFactory(),
             'provider': 'provider',
         })
 


### PR DESCRIPTION
Removed beacause this field is not necessary, furthermore it's weird - office_info is ``OneToOneField`` therefore bulk edit shouldn't contains field of that type.