### PR TITLE
Feature/statuses spilt

### DIFF
--- a/src/ralph_assets/forms.py
+++ b/src/ralph_assets/forms.py
@@ -415,13 +415,13 @@ class BulkEditAssetForm(DependencyForm, ModelForm):
         ]
 
     barcode = BarcodeField(max_length=200, required=False)
-    source = ChoiceField(
-        required=False,
-        choices=[('', '----')] + AssetSource(),
-    )
     owner = AutoCompleteSelectField(
         LOOKUPS['asset_user'],
         required=False,
+    )
+    source = ChoiceField(
+        required=False,
+        choices=[('', '----')] + AssetSource(),
     )
     user = AutoCompleteSelectField(
         LOOKUPS['asset_user'],
@@ -508,6 +508,9 @@ class BackOfficeBulkEditAssetForm(BulkEditAssetForm):
         label=_('Purpose'),
         required=False,
     )
+    status = ChoiceField(
+        choices=AssetStatus.back_office(required=True), required=False,
+    )
     type = ChoiceField(
         required=True,
         choices=[('', '----')] + [
@@ -531,6 +534,9 @@ class DataCenterBulkEditAssetForm(BulkEditAssetForm):
         plugin_options=dict(
             add_link='/admin/ralph_assets/assetmodel/add/?name=',
         )
+    )
+    status = ChoiceField(
+        choices=AssetStatus.data_center(required=True), required=False,
     )
 
 
@@ -1301,6 +1307,9 @@ class BackOfficeAddDeviceForm(AddDeviceForm):
         required=False,
         label=_('Service catalog'),
     )
+    status = ChoiceField(
+        choices=AssetStatus.back_office(required=True), required=False,
+    )
 
     def __init__(self, *args, **kwargs):
         super(BackOfficeAddDeviceForm, self).__init__(*args, **kwargs)
@@ -1330,6 +1339,9 @@ class DataCenterAddDeviceForm(AddDeviceForm):
         LOOKUPS['service'],
         required=True,
         label=_('Service catalog'),
+    )
+    status = ChoiceField(
+        choices=AssetStatus.data_center(required=True), required=False,
     )
 
     def __init__(self, *args, **kwargs):
@@ -1451,6 +1463,9 @@ class BackOfficeEditDeviceForm(ReadOnlyFieldsMixin, EditDeviceForm):
         required=False,
         label=_('Service catalog'),
     )
+    status = ChoiceField(
+        choices=AssetStatus.back_office(required=True), required=False,
+    )
 
     def __init__(self, *args, **kwargs):
         super(BackOfficeEditDeviceForm, self).__init__(*args, **kwargs)
@@ -1502,6 +1517,9 @@ class DataCenterEditDeviceForm(ReadOnlyFieldsMixin, EditDeviceForm):
         LOOKUPS['service'],
         required=True,
         label=_('Service catalog'),
+    )
+    status = ChoiceField(
+        choices=AssetStatus.data_center(required=True), required=False,
     )
 
     def __init__(self, *args, **kwargs):
@@ -1763,6 +1781,9 @@ class DataCenterSearchAssetForm(SearchAssetForm):
         help_text=None,
         plugin_options={'disable_confirm': True}
     )
+    status = ChoiceField(
+        choices=AssetStatus.data_center(required=False), required=False,
+    )
     without_assigned_location = BooleanField(
         required=False,
         help_text=(
@@ -1801,6 +1822,9 @@ class BackOfficeSearchAssetForm(SearchAssetForm):
         required=False,
     )
     segment = CharField(max_length=256, required=False)
+    status = ChoiceField(
+        choices=AssetStatus.back_office(required=False), required=False,
+    )
 
     def __init__(self, *args, **kwargs):
         super(BackOfficeSearchAssetForm, self).__init__(*args, **kwargs)

--- a/src/ralph_assets/models_assets.py
+++ b/src/ralph_assets/models_assets.py
@@ -199,6 +199,40 @@ class AssetStatus(Choices):
     free = _("free")
     reserved = _("reserved")
 
+    @classmethod
+    def _filter_status(cls, asset_type, required=True):
+        """
+        Filter choices depending on 2 things:
+
+            1. defined ASSET_STATUSES in settings (if not defined returns all
+                statuses)
+            2. passed *asset_type* (which is one of keys from ASSET_STATUSES)
+
+        :param required: prepends empty value to choices
+        """
+        customized = getattr(settings, 'ASSET_STATUSES', None)
+        found = [] if required else [('', '----')]
+        if not customized:
+            found.extend(AssetStatus())
+            return found
+        for key in customized[asset_type]:
+            try:
+                choice = getattr(AssetStatus, key)
+            except AttributeError:
+                msg = ("No such choice {!r} in AssetStatus"
+                       " - check settings").format(key)
+                raise Exception(msg)
+            found.append((choice.id, choice.name,))
+        return found
+
+    @classmethod
+    def data_center(cls, required):
+        return AssetStatus._filter_status('data_center', required)
+
+    @classmethod
+    def back_office(cls, required):
+        return AssetStatus._filter_status('back_office', required)
+
 
 class AssetSource(Choices):
     _ = Choices.Choice

--- a/src/ralph_assets/settings.py
+++ b/src/ralph_assets/settings.py
@@ -2,6 +2,16 @@
 ASSETS_CHANGELOG_URL = ''  # TODO: set it, when it's formed
 DEFAULT_DEPRECATION_RATE = 25
 
+# customize asset's statuses per its type (datacenter or backoffice)
+# possible choices are:
+#     new, in_progress, waiting_for_release, used, loan, damaged, liquidated,
+#     in_service, in_repair, ok, installed, free, reserved,
+# e.g.:
+# ASSET_STATUSES = {
+#     'back_office': ['new', 'in_progress', 'used'],
+#     'data_center': ['new'],
+# }
+
 ASSETS_REPORTS = {
     'ENABLE': False,
     'INVOICE_REPORT': {'SLUG': 'invoice-report'},

--- a/src/ralph_assets/tests/functional/tests_dependency.py
+++ b/src/ralph_assets/tests/functional/tests_dependency.py
@@ -13,6 +13,7 @@ from ralph.account.models import Region
 from ralph_assets.models_assets import (
     Asset,
     AssetCategory,
+    AssetStatus,
     MODE2ASSET_TYPE,
 )
 from ralph_assets.tests.utils.assets import (
@@ -51,6 +52,7 @@ class TestDependency(TestCase):
             'slot_no': 3,
             'slots': 2,
             'sn': '123456789',
+            'status': AssetStatus.new.id,
             'type': MODE2ASSET_TYPE['dc'].id,
             'warehouse': self.warehouse.id,
         })
@@ -72,6 +74,7 @@ class TestDependency(TestCase):
             'region': Region.get_default_region().id,
             'slots': '',
             'sn': '123456789',
+            'status': AssetStatus.new.id,
             'type': MODE2ASSET_TYPE['dc'].id,
             'warehouse': self.warehouse.id,
         })


### PR DESCRIPTION
Added feature allowing separate asset's statuses for data center and separate for back office.
Main change was to filter choices on forms. Rest stays as before.