### PR TITLE
Made AssetModel's Category required.

### DIFF
--- a/src/ralph_assets/models_assets.py
+++ b/src/ralph_assets/models_assets.py
@@ -285,7 +285,7 @@ class AssetModel(
     manufacturer = models.ForeignKey(
         AssetManufacturer, on_delete=models.PROTECT, blank=True, null=True)
     category = models.ForeignKey(
-        'AssetCategory', null=True, blank=True, related_name='models'
+        'AssetCategory', null=True, related_name='models'
     )
     power_consumption = models.IntegerField(
         verbose_name=_("Power consumption"),


### PR DESCRIPTION
Before, category was optional which was incorrect.
Now it's required.
Change is a fix.