### PR TITLE
Change permission on visualization api.

### DIFF
--- a/src/ralph_assets/rest/asset_info_per_rack.py
+++ b/src/ralph_assets/rest/asset_info_per_rack.py
@@ -12,7 +12,7 @@ from rest_framework.views import APIView
 
 from ralph_assets.models_assets import Orientation, Rack
 from ralph_assets.models_dc_assets import RackAccessory
-from ralph_assets.views.base import ACLGateway
+from ralph.ui.views.common import ACLGateway
 from ralph_assets.rest.serializers.models_dc_asssets import (
     AssetSerializer,
     RackAccessorySerializer,

--- a/src/ralph_assets/rest/data_centers_racks.py
+++ b/src/ralph_assets/rest/data_centers_racks.py
@@ -10,7 +10,7 @@ from django.http import Http404
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from ralph_assets.views.base import ACLGateway
+from ralph.ui.views.common import ACLGateway
 from ralph_assets.models_assets import DataCenter
 from ralph_assets.rest.serializers.models_dc_asssets import DCSerializer
 


### PR DESCRIPTION
Before, api visualization required asset-permission.
Now api visualization requires core-permission, because visualization is
requested from core.