### PR TITLE
Added W503 to ignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ coverage:
 	coverage report
 
 flake:
-	flake8 --exclude="migrations" --statistics src/ralph_assets
+	flake8 --exclude="migrations" --statistics --ignore=W503 src/ralph_assets
 
 runserver:
 	ralph runserver


### PR DESCRIPTION
In new version of pep8 (1.6.2) added W503 to error. See
https://github.com/jcrocholl/pep8/issues/197