### PR TITLE
Fixed 'status - model' report.

### DIFF
--- a/src/ralph_assets/views/report.py
+++ b/src/ralph_assets/views/report.py
@@ -249,6 +249,7 @@ class StatusModelReport(BaseReport):
                 name=item['model__name'],
                 count=item['num'],
                 parent=get_desc(AssetStatus, item['status']),
+                unique=False,
             )
 
 


### PR DESCRIPTION
Report 'status - model' was generated incorrectly.
This means if a specific model was used with more then one status
(eg. 'new' and 'in use') it was only added to first found (because of
unique=True)
This change is a bugfix.