### PR TITLE
Moved PostTransitionException to seperate file.

### DIFF
--- a/src/ralph_assets/exceptions.py
+++ b/src/ralph_assets/exceptions.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+class PostTransitionException(Exception):
+    """General exception to be thrown in *post_transition* signal receivers.
+    Exception message is used to inform user."""

--- a/src/ralph_assets/tests/functional/tests_transitions.py
+++ b/src/ralph_assets/tests/functional/tests_transitions.py
@@ -19,6 +19,7 @@ from django.test.utils import override_settings
 from ralph.ui.tests.global_utils import login_as_su
 from ralph.ui.tests.global_utils import UserFactory
 from ralph_assets import signals
+from ralph_assets.exceptions import PostTransitionException
 from ralph_assets.models_assets import Asset
 from ralph_assets.models_transition import Action
 from ralph_assets.tests.utils import MessagesTestMixin
@@ -184,8 +185,7 @@ class TestTransitionHostname(MessagesTestMixin, TestCase):
         def post_transition_handler(
             sender, user, assets, transition, **kwargs
         ):
-            from ralph_assets.views import transition
-            raise transition.PostTransitionException(
+            raise PostTransitionException(
                 "Unable to generate document - try later, please."
             )
 

--- a/src/ralph_assets/views/transition.py
+++ b/src/ralph_assets/views/transition.py
@@ -22,6 +22,7 @@ from inkpy.api import generate_pdf
 from lck.django.common import nested_commit_on_success
 
 from ralph_assets import signals
+from ralph_assets.exceptions import PostTransitionException
 from ralph_assets.forms_transitions import TransitionForm
 from ralph_assets.models import (
     ReportOdtSourceLanguage,
@@ -39,11 +40,6 @@ from ralph_assets.views.search import _AssetSearch
 
 
 logger = logging.getLogger(__name__)
-
-
-class PostTransitionException(Exception):
-    """General exception to be thrown in *post_transition* signal receivers.
-    Exception message is used to inform user."""
 
 
 class TransitionDispatcher(object):


### PR DESCRIPTION
Holding defintion of PostTransitionException in file transition.py
caused errors during imports.