### PR TITLE
Fixed raise of NoReverseMatch in API

### DIFF
--- a/src/ralph_assets/rest/serializers/models_dc_asssets.py
+++ b/src/ralph_assets/rest/serializers/models_dc_asssets.py
@@ -28,10 +28,13 @@ class CoreDeviceMixin(object):
         """
         Return the URL to device in core.
         """
+        url = None
         device_core_id = obj.device_info.ralph_device_id
-        return reverse('search', kwargs={
-            'details': 'info', 'device': device_core_id
-        })
+        if device_core_id:
+            url = reverse('search', kwargs={
+                'details': 'info', 'device': device_core_id
+            })
+        return url
 
 
 class RelatedAssetSerializer(CoreDeviceMixin, serializers.ModelSerializer):


### PR DESCRIPTION
NoReverseMatch raised when `device_core_id` is `None`.