### PR TITLE
fixed assets status choice on form

### DIFF
--- a/src/ralph_assets/models_assets.py
+++ b/src/ralph_assets/models_assets.py
@@ -222,7 +222,7 @@ class AssetStatus(Choices):
                 msg = ("No such choice {!r} in AssetStatus"
                        " - check settings").format(key)
                 raise Exception(msg)
-            found.append((choice.id, choice.name,))
+            found.append((choice.id, unicode(choice)))
         return found
 
     @classmethod


### PR DESCRIPTION
fixed assets status choice values (show description instead of name/key) on form when ASSET_STATUSES is defined in settings