### PR TITLE
Post_transition signal made as non-blocking.

### DIFF
--- a/src/ralph_assets/tests/functional/tests_transitions.py
+++ b/src/ralph_assets/tests/functional/tests_transitions.py
@@ -58,6 +58,8 @@ unassign_actions = [
     'unassign_licences'
 ]
 
+SUCCESS_MSG = "Transitions performed successfully"
+
 
 def prepare_transition(slug, actions=None, required_report=False):
     action_list = actions or [
@@ -161,7 +163,7 @@ class TestTransitionHostname(MessagesTestMixin, TestCase):
 
     def test_successful_post_transition(self):
         """
-        Transition is done successfully.
+        Transition is done successfully when post_transition success.
         """
         @django.dispatch.receiver(signals.post_transition)
         def post_transition_handler(
@@ -173,29 +175,30 @@ class TestTransitionHostname(MessagesTestMixin, TestCase):
         response = self.client.post(url, post_data, follow=True)
         self.assertEqual(len(response.context['messages']), 1)
         self.assertEqual(
-            str(response.context['messages']._loaded_messages[0]),
-            "Transitions performed successfully",
+            str(response.context['messages']._loaded_messages[0]), SUCCESS_MSG,
         )
 
     def test_failed_post_transition(self):
         """
-        Transition is done unsuccessfully.
+        Transition is done successfully despite of failed post_transition
+        signal.
         """
+        error_msg = "Unable to generate document - try later, please."
+
         @django.dispatch.receiver(signals.post_transition)
         def post_transition_handler(
             sender, user, assets, transition, **kwargs
         ):
-            raise PostTransitionException(
-                "Unable to generate document - try later, please."
-            )
+            raise PostTransitionException(error_msg)
 
         url, post_data = self._get_simple_transition_data()
         response = self.client.post(url, post_data, follow=True)
-        self.assertEqual(len(response.context['messages']), 1)
-        self.assertEqual(
-            str(response.context['messages']._loaded_messages[0]),
-            "Unable to generate document - try later, please.",
-        )
+        found_msges = {
+            str(msg) for msg in response.context['messages']._loaded_messages
+        }
+        self.assertEqual(len(found_msges), 2)
+        for msg in [error_msg, SUCCESS_MSG]:
+            self.assertIn(msg, found_msges)
 
 
 @override_settings(ASSETS_TRANSITIONS=ASSETS_TRANSITIONS)

--- a/src/ralph_assets/views/transition.py
+++ b/src/ralph_assets/views/transition.py
@@ -405,17 +405,15 @@ class TransitionView(ActiveSubmoduleByAssetMixin, _AssetSearch):
             try:
                 dispatcher.run()
             except PostTransitionException as e:
-                self.transition_ended = False
                 messages.error(self.request, _(e.message))
-            else:
-                self.report_file_path = dispatcher.report_file_patch
-                self.report_file_name = dispatcher.get_report_file_name
-                self.transition_history = dispatcher.get_transition_history_object()  # noqa
-                messages.success(
-                    self.request,
-                    _("Transitions performed successfully"),
-                )
-                self.transition_ended = True
+            self.report_file_path = dispatcher.report_file_patch
+            self.report_file_name = dispatcher.get_report_file_name
+            self.transition_history = dispatcher.get_transition_history_object()  # noqa
+            messages.success(
+                self.request,
+                _("Transitions performed successfully"),
+            )
+            self.transition_ended = True
             return super(TransitionView, self).get(*args, **kwargs)
         messages.error(self.request, _('Please correct errors.'))
         return super(TransitionView, self).get(*args, **kwargs)


### PR DESCRIPTION
Before:
transition execution was interrupted by failed post_transition signal
Now:
transition is executed despite of post_transition result

@andrzej-jankowski @mkurek 