### PR TITLE
Added the region to bulk edit

### DIFF
--- a/src/ralph_assets/licences/forms.py
+++ b/src/ralph_assets/licences/forms.py
@@ -322,6 +322,7 @@ class BulkEditLicenceForm(LicenceForm):
             'sn',
             'remarks',
             'budget_info',
+            'region',
         )
     sn = forms.CharField(label=_('Licence key'))
     remarks = forms.CharField(label=_('Additional remarks'), required=False)


### PR DESCRIPTION
For unknown reasons (probably inheritance) the 'region' field was displayed
in the licence bulkedit, but didn't get saved. Adding 'region' to fields
explicitly fixed this problem.