### PR TITLE
Simple method for generate unique str instead of uuid

### DIFF
--- a/src/ralph_assets/tests/functional/tests_view.py
+++ b/src/ralph_assets/tests/functional/tests_view.py
@@ -57,7 +57,7 @@ from ralph_assets.tests.utils.assets import (
     DeviceInfoFactory,
     ServiceFactory,
     WarehouseFactory,
-    generate_barcode,
+    unique_str,
     generate_imei,
     get_device_info_dict,
 )
@@ -557,7 +557,7 @@ class TestDataCenterDevicesView(TestDevicesView, TestRegions, BaseViewsTest):
         form_data.update({
             'sn': ','.join(sns),
             'barcode': ','.join(
-                [generate_barcode() for i in xrange(2)],
+                [unique_str() for i in xrange(2)],
             ),
             'ralph_device_id': '',
         })

--- a/src/ralph_assets/tests/utils/assets.py
+++ b/src/ralph_assets/tests/utils/assets.py
@@ -8,7 +8,6 @@ from __future__ import unicode_literals
 import datetime
 import itertools
 import random
-from uuid import uuid1
 
 import factory
 from django.template.defaultfilters import slugify
@@ -55,12 +54,10 @@ category_code_set = 'ABCDEFGHIJKLMNOPRSTUVWXYZ1234567890'
 category_code_combinations = itertools.product(category_code_set, repeat=2)
 
 
-def generate_sn():
-    return str(uuid1())
-
-
-def generate_barcode():
-    return str(uuid1())
+def unique_str():
+    unique_str.counter += 1
+    return 'UNIQUE-{0:0>5}'.format(unique_str.counter)
+unique_str.counter = 0
 
 
 def generate_imei(n):
@@ -95,11 +92,11 @@ class OfficeInfoFactory(DjangoModelFactory):
 
     @lazy_attribute
     def license_key(self):
-        return str(uuid1())
+        return str(unique_str())
 
     @lazy_attribute
     def coa_number(self):
-        return str(uuid1())
+        return str(unique_str())
 
 
 class ServiceFactory(DjangoModelFactory):
@@ -257,7 +254,7 @@ class AssetFactory(DjangoModelFactory):
 
     @lazy_attribute
     def sn(self):
-        return generate_sn()
+        return unique_str()
 
 
 class BaseAssetFactory(DjangoModelFactory):
@@ -301,7 +298,7 @@ class BaseAssetFactory(DjangoModelFactory):
 
     @lazy_attribute
     def barcode(self):
-        return generate_barcode()
+        return unique_str()
 
     @lazy_attribute
     def created_by(self):
@@ -313,7 +310,7 @@ class BaseAssetFactory(DjangoModelFactory):
 
     @lazy_attribute
     def sn(self):
-        return generate_sn()
+        return unique_str()
 
     @factory.post_generation
     def device_environment(self, create, extracted, **kwargs):

--- a/src/ralph_assets/tests/utils/licences.py
+++ b/src/ralph_assets/tests/utils/licences.py
@@ -8,7 +8,6 @@ from __future__ import unicode_literals
 import datetime
 from decimal import Decimal
 from random import randint, randrange
-from uuid import uuid1
 
 from factory import (
     fuzzy,
@@ -29,6 +28,7 @@ from ralph_assets.licences.models import (
     SoftwareCategory,
 )
 from ralph_assets.tests.utils.assets import (
+    unique_str,
     AssetFactory,
     AssetManufacturerFactory,
     AssetOwnerFactory,
@@ -78,7 +78,7 @@ class LicenceFactory(DjangoModelFactory):
 
     @lazy_attribute
     def niw(self):
-        return str(uuid1())
+        return str(unique_str())
 
     @lazy_attribute
     def number_bought(self):
@@ -95,7 +95,7 @@ class LicenceFactory(DjangoModelFactory):
 
     @lazy_attribute
     def sn(self):
-        return str(uuid1())
+        return str(unique_str())
 
     @post_generation
     def users(self, create, extracted, **kwargs):


### PR DESCRIPTION
We don't need sophisticated method like ``uuid.uuid1`` to generate unique string in tests. After this change execution time of tests should be decrease about few seconds.