### PR TITLE
Changed STATICFILES_STORAGE to non-chached in tests.

### DIFF
--- a/src/ralph_assets/settings-test-assets.py
+++ b/src/ralph_assets/settings-test-assets.py
@@ -13,3 +13,5 @@ PLUGGABLE_APPS = ['cmdb', 'assets']
 SOUTH_TESTS_MIGRATE = False
 
 ASSETS_AUTO_ASSIGN_HOSTNAME = True
+
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'


### PR DESCRIPTION
Recently STATICFILES_STORAGE was changed to CachedStaticFilesStorage in
Ralph-core. That change broke assets tests, so update on assets test settings
is required. This change fixes it.