### PR TITLE
Added previous value of user, owner, loan_end_date before run transition

### DIFF
--- a/src/ralph_assets/tests/functional/tests_transitions.py
+++ b/src/ralph_assets/tests/functional/tests_transitions.py
@@ -258,7 +258,12 @@ class TestTransition(TestCase):
 
     @prepare_transition('return-asset', unassign_actions, required_report=True)
     def test_transition_form_unassign(self):
-        self._prepare_assets({'user': self.user})
+        today = date.today()
+        self._prepare_assets({
+            'user': self.user,
+            'owner': self.owner,
+            'loan_end_date': today,
+        })
         self._assign_licence_to_assets()
         asset_ids = Asset.objects.values_list('id', flat=True)
         url_params = {'select': asset_ids, 'transition_type': 'return-asset'}
@@ -270,6 +275,11 @@ class TestTransition(TestCase):
             ).distinct().count(),
             1,
         )
+        for asset in self.assets:
+            asset = Asset.objects.get(id=asset.pk)
+            self.assertEqual(asset.user, None)
+            self.assertEqual(asset.owner, None)
+            self.assertEqual(asset.loan_end_date, None)
 
     @prepare_transition('return-asset', unassign_actions, required_report=True)
     def test_transition_history_file(self):

--- a/src/ralph_assets/views/transition.py
+++ b/src/ralph_assets/views/transition.py
@@ -89,6 +89,7 @@ class TransitionDispatcher(object):
 
     def _action_unassign_user(self):
         for asset in self.assets:
+            asset.previous_user = asset.user
             asset.user = None
             asset.save(user=self.logged_user)
 
@@ -99,11 +100,13 @@ class TransitionDispatcher(object):
 
     def _action_unassign_loan_end_date(self):
         for asset in self.assets:
+            asset.previous_loan_end_date = asset.loan_end_date
             asset.loan_end_date = None
             asset.save(user=self.logged_user)
 
     def _action_unassign_owner(self):
         for asset in self.assets:
+            asset.previous_owner = asset.owner
             asset.owner = None
             asset.save(user=self.logged_user)
 


### PR DESCRIPTION
Is useful e.g. in signal when we want previous user of asset after it return.