### PR TITLE
Changed scrooge api to return dc.id instead of warehouse.id.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Change Log
 ----------
 
+DEV
+~~~
+
+* [scrooge-api]: changed warehouse source from warehouse to datacenter
+
+
 2.5.0
 ~~~~~
 

--- a/src/ralph_assets/api_scrooge.py
+++ b/src/ralph_assets/api_scrooge.py
@@ -80,6 +80,10 @@ def get_assets(date):
             ralph_device = device_info.get_ralph_device()
             if ralph_device:
                 hostname = ralph_device.name
+        try:
+            data_center_id = asset.device_info.data_center_id
+        except AttributeError:
+            data_center_id = None
 
         yield {
             'asset_id': asset.id,
@@ -89,7 +93,7 @@ def get_assets(date):
             'environment_id': asset.device_environment_id,
             'sn': asset.sn,
             'barcode': asset.barcode,
-            'warehouse_id': asset.warehouse_id,
+            'warehouse_id': data_center_id,
             'cores_count': asset.cores_count,
             'power_consumption': asset.model.power_consumption,
             'collocation': asset.model.height_of_device,

--- a/src/ralph_assets/tests/unit/test_api_scrooge.py
+++ b/src/ralph_assets/tests/unit/test_api_scrooge.py
@@ -77,6 +77,10 @@ class TestApiScrooge(TestCase):
         ])
 
     def _compare_asset(self, asset, api_result, date, name):
+        try:
+            data_center_id = asset.device_info.data_center_id
+        except AttributeError:
+            data_center_id = None
         self.assertEquals(api_result, {
             'asset_id': asset.id,
             'device_id': asset.device_info.ralph_device_id,
@@ -85,7 +89,7 @@ class TestApiScrooge(TestCase):
             'environment_id': asset.device_environment_id,
             'sn': asset.sn,
             'barcode': asset.barcode,
-            'warehouse_id': asset.warehouse_id,
+            'warehouse_id': data_center_id,
             'cores_count': asset.cores_count,
             'power_consumption': asset.model.power_consumption,
             'collocation': asset.model.height_of_device,


### PR DESCRIPTION
Warehouse was a good data source for Scrooge until location fields was
introduced. Now when location fields are present, datacenter is the better
source, so this change comes.

Depends on:
https://github.com/allegro/ralph_pricing/pull/437