### PR TITLE
Extended assets api to search by ralph_device_id.

### DIFF
--- a/src/ralph_assets/api.py
+++ b/src/ralph_assets/api.py
@@ -15,6 +15,7 @@ from tastypie.constants import ALL, ALL_WITH_RELATIONS
 from tastypie.resources import ModelResource
 from tastypie.throttle import CacheThrottle
 
+from ralph.discovery.models import Device
 from ralph.urls import LATEST_API
 from ralph_assets.models import (
     Asset,
@@ -235,12 +236,25 @@ class LicenceResource(ModelResource):
         )
 
 
+class SimpleDeviceResource(ModelResource):
+    class Meta:
+        queryset = Device.objects.all()
+        fields = ['id', 'barcode', 'sn', 'name']
+        filtering = {
+            'id': ALL,
+        }
+
+
 class DeviceInfoResource(ModelResource):
+    ralph_device = fields.ForeignKey(
+        SimpleDeviceResource, 'ralph_device', full=True,
+    )
+
     class Meta:
         queryset = DeviceInfo.objects.all()
         list_allowed_methods = ['get']
         filtering = {
-            'ralph_device__id': ALL,
+            'ralph_device': ALL_WITH_RELATIONS,
         }
         excludes = ["cache_version", "created", "deleted", "modified"]
 

--- a/src/ralph_assets/tests/unit/test_api.py
+++ b/src/ralph_assets/tests/unit/test_api.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import json
+
+from django.core.cache import cache
+from django.test import TestCase
+from ralph.ui.tests.global_utils import UserFactory
+
+from ralph_assets.tests.utils.assets import DCAssetFactory
+
+
+class TestApi(TestCase):
+
+    def setUp(self):
+        self.user = UserFactory()
+        self.api_login = {
+            'format': 'json',
+            'username': self.user.username,
+            'api_key': self.user.api_key.key,
+        }
+        cache.delete("api_user_accesses")
+
+    def get_response(self, resource='assets', data=None):
+        path = "/assets/api/v0.9/{resource}/".format(resource=resource)
+        if data:
+            self.api_login.update(data)
+        response = self.client.get(
+            path=path, data=self.api_login, format='json',
+        )
+        self.assertEqual(response.status_code, 200)
+        return response
+
+    def resource_json(self, resource='assets', data=None):
+        response = self.get_response(resource='assets', data=data)
+        return json.loads(response.content)
+
+    def test_asset_returned(self):
+        asset = DCAssetFactory()
+        data = {
+            'id': asset.id,
+        }
+        api_result = self.resource_json('assets', data)
+        for field in ['id', 'sn', 'barcode']:
+            api_value = api_result['objects'][0][field]
+            asset_value = getattr(asset, field)
+            msg = 'field {}={!r} instead of {!r}'.format(
+                field, api_value, asset_value,
+            )
+            self.assertEqual(api_value, asset_value, msg)
+
+    def test_asset_found_by_valid_ralph_device_id(self):
+        asset = DCAssetFactory()
+        data = {
+            'id': asset.id,
+            'device_info__ralph_device__id': asset.device_info.ralph_device_id,
+        }
+        api_result = self.resource_json('assets', data)
+        self.assertEqual(len(api_result['objects']), 1)
+        self.assertEqual(api_result['objects'][0]['id'], asset.id)
+
+    def test_asset_missing_by_invalid_ralph_device_id(self):
+        asset = DCAssetFactory()
+        asset2 = DCAssetFactory()
+        invalid_ralph_device_id = asset2.device_info.ralph_device_id
+        data = {
+            'id': asset.id,
+            'device_info__ralph_device__id': invalid_ralph_device_id,
+        }
+        api_result = self.resource_json('assets', data)
+        self.assertEqual(len(api_result['objects']), 0)


### PR DESCRIPTION
After ralph_device_id became a real foreign key, asset API stopped working.
This change replace assets ralph_device_id with a resource (before it was
a string) to fix it.