### PR TITLE
Fixed wrong display devices on same position

### DIFF
--- a/src/ralph_assets/models_assets.py
+++ b/src/ralph_assets/models_assets.py
@@ -1023,6 +1023,7 @@ class Asset(
                     device_info__position=self.device_info.position,
                     device_info__rack=self.device_info.rack,
                     device_info__orientation=orientation,
+                    model__category__is_blade=True,
                 ).exclude(id=self.id)
             ))
         assets = [


### PR DESCRIPTION
This PR fixed incorrect display devices in ``DC View`` when two or more devices is on same position in rack but different orientation.